### PR TITLE
Add 🤗 str function

### DIFF
--- a/src/huggingface/HuggingFace.jl
+++ b/src/huggingface/HuggingFace.jl
@@ -30,6 +30,10 @@ macro hgf_str(name)
   :(load_hgf_pretrained($(esc(name))))
 end
 
+macro 🤗_str(name)
+  :(load_hgf_pretrained($(esc(name))))
+end
+
 """
   `load_hgf_pretrained(name)`
 


### PR DESCRIPTION
Right now there is a `hgf_str` function which downloads a model name. This is very convenient, as we can do things like `hgf"princeton-nlp/sup-simcse-bert-base-uncased"`. 

This PR duplicates that macro and adds `🤗_str` macro. 

The only reason for that is you we can do things like e.g. 

```julia
text_encoder, model = 🤗"princeton-nlp/sup-simcse-bert-base-uncased"
```

This is less practical in most cases but can "demo" better.